### PR TITLE
Fix puppetca autosign

### DIFF
--- a/check_csr.rb
+++ b/check_csr.rb
@@ -19,7 +19,7 @@ def sign_psk(csr, certname, value)
   if value == autosign_psk
     sign_csr(csr, certname)
   else
-    exit 1
+    exit 2
   end
 end
 
@@ -36,7 +36,7 @@ csr = OpenSSL::X509::Request.new(request)
 
 challenge = csr.attributes.select { |a| a.oid == "challengePassword" }.first.value.value.first.value
 
-exit 1 if challenge.nil?
+exit 3 if challenge.nil?
 
 challenge_method, challenge_value = challenge.match(/(?:([^:]+):)?(.+)/).captures()
 
@@ -46,4 +46,4 @@ elsif challenge_method == 'psk'
   sign_psk(csr, ARGV[0], challenge_value)
 end
 
-exit 1
+exit 4

--- a/check_csr.rb
+++ b/check_csr.rb
@@ -25,8 +25,7 @@ end
 
 def sign_csr(csr, certname)
   if ! csr.attributes.select { |a| a.oid == "ExtReq" }.nil?
-    # https://tickets.puppetlabs.com/browse/SERVER-1005
-    `puppet cert --allow-dns-alt-names --ssldir /etc/puppetlabs/puppet/ssl sign #{certname}`
+    # Everything is fine, tell puppetca to sign the CSR
     exit 0
   end
 end

--- a/check_csr.rb
+++ b/check_csr.rb
@@ -38,10 +38,10 @@ challenge = csr.attributes.select { |a| a.oid == "challengePassword" }.first.val
 
 exit 1 if challenge.nil?
 
-challenge_method, challenge_value = challenge.match(/(?:([^;]+);)?(.+)/).captures()
+challenge_method, challenge_value = challenge.match(/(?:([^:]+):)?(.+)/).captures()
 
-if challenge_method == 'rancher' or challenge_method.nil?
-  sign_rancher(csr, ARGV[0], challenge_value)
+if challenge_method == 'puppet' or challenge_method.nil?
+  sign_rancher(csr, ARGV[0], challenge)
 elsif challenge_method == 'psk'
   sign_psk(csr, ARGV[0], challenge_value)
 end


### PR DESCRIPTION
Auto-signing in Rancher infra was completely broken.
This PR fixes the auto-signing using Challenge inside a rancher environment.
Broken things were:
- the challenge method in rancher env was not "rancher" but "puppet"
- the challenge method and key were not separated using a ";" (semi-colon) but ":" (colon)
- the complete challenge (method + key) not only the key, must be used in rancher to check against the rancher API
- the signing of the CSR must not be performed inside the policy checking script, the return code of the checking script is used by puppetca to know if it should sign or not

Also to simplify debugging different return codes are now used in each exit statement...
